### PR TITLE
Add example qmd for confluence publish

### DIFF
--- a/confluence-qmds/cormac.qmd
+++ b/confluence-qmds/cormac.qmd
@@ -1,0 +1,18 @@
+# Test qmd file for publishing to confluence
+
+```{python}
+# Code block
+
+import numpy as np
+
+a = np.array([1, 2, 3])
+
+print(a)
+```
+
+- See section [below](#heading2)
+
+## Heading 2 {#heading2}
+
+- Some more things
+- A **very important point**


### PR DESCRIPTION
Added an example qmd for confluence publish.

- The internal cross reference is broken on confluence but works on the html render
- I've noticed in the past also that Mermaid and Graphviz diagrams cause issues when "republishing", i.e. if any changes are made to the page, and then published again - Quarto is not a fan

Command used for publishing:

`quarto publish confluence cormac.qmd --no-browser`