### PR TITLE
Remove autodiscovered images from listing

### DIFF
--- a/index.qmd
+++ b/index.qmd
@@ -5,6 +5,13 @@ listing:
   sort: "date desc"
   type: default
   categories: true
+  fields: 
+    - title
+    - subtitle
+    - author
+    - date
+    - description
+    - categories
 ---
 
 This is a series of short lessons in various technologies useful to our work.

--- a/index.qmd
+++ b/index.qmd
@@ -10,7 +10,6 @@ listing:
     - subtitle
     - author
     - date
-    - description
     - categories
 ---
 


### PR DESCRIPTION
Most posts in the listing do not have images.
This PR removes the images field so autodiscovered images aren't added to the listing page.