### PR TITLE
Add GitHub Actions workflow for deploying PR previews

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -12,6 +12,8 @@ on:
 concurrency: preview-${{ github.ref }}
 jobs:
   deploy-preview:
+    # only run if PR is from the same repo (not from a fork), see https://github.com/rossjrw/pr-preview-action/pull/6
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
This PR adds a GHA workflow for automatically deploying PR previews using https://github.com/marketplace/actions/deploy-pr-preview