### PR TITLE
Add AGENTS.md with a literature-grounded writing/review checklist

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ complete beginners to it, others already use it daily.
   [write-up.qmd](write-up.qmd).
 - **Preview locally** with `quarto preview` (or `pixi run preview`).
 
-## Writing and reviewing walkthrough posts
+## Writing a walkthrough post
 
 These are standing rules for this repo's posts, in addition to whatever
 the human author asks for on a given draft. They're grounded in
@@ -42,6 +42,12 @@ learning-science and technical-writing research — see
 [References](#references) — not house-style opinion, so don't relax
 them without a reason that would also count as a reason in that
 literature.
+
+This section applies when drafting a post, or self-reviewing one before
+it's opened as a PR. For reviewing a PR someone else has already
+submitted, see [Reviewing a submitted walkthrough
+PR](#reviewing-a-submitted-walkthrough-pr) instead — a narrower set of
+rules applies there.
 
 ### Standing rules
 
@@ -162,7 +168,53 @@ self-review, since check 10 above specifically requires it:
 Then run a **scope pass** over the result specifically for checks 1, 4,
 5, and 12.
 
-### Posting review comments
+## Reviewing a submitted walkthrough PR
+
+A PR always follows an already-given talk, and is usually the
+presenter's rough draft — not written against the checklist above. The
+point of reviewing it is to get the post merged so readers have it.
+
+- **Merge condition.** The only requirement for merging is that the post
+  renders correctly (`quarto preview`/render succeeds — valid
+  frontmatter, no broken includes, images and links resolve).
+- **Merging is manual.** A human merges the PR, or gives explicit
+  go-ahead first — never merge automatically as part of this process,
+  even once the render check passes.
+- **Scope test.** A fix or suggestion confined to a single paragraph is
+  in scope, whichever checklist principle motivates it (tightening a
+  sentence, cutting one redundant clause, moving a code block next to
+  its explanation). A change spanning multiple paragraphs or sections —
+  reordering sections, cutting/expanding whole paragraphs, reworking a
+  section's scope or depth — is out of scope; don't suggest it here, not
+  even as an optional "nice to have." The size of the change decides
+  borderline cases, not which checklist principle it comes from.
+- **In scope:** technical accuracy (commands/config/behaviour/output
+  against current docs — checklist item 14); broken links/images;
+  repo-convention compliance (required frontmatter fields, correct
+  `draft` flag handling, file/branch naming, categories); mechanical
+  style (British spelling, obvious typos/grammar); any single-paragraph-
+  scoped edit from the drafting checklist (e.g. one coherence,
+  redundancy, justification-clause, or signaling fix within a
+  paragraph).
+- **Out of scope:** multi-paragraph or section-level structural
+  changes — narrative-arc reordering, mode-check rewrites or
+  scope-to-session trims spanning more than one paragraph, artifact-vs-
+  narration restructuring across a section, curse-of-knowledge or
+  expertise-reversal rewrites touching many sentences throughout.
+
+Process:
+
+1. Post one PR comment listing the in-scope items found, once a human
+   has approved its exact text.
+2. Merge once the post renders correctly and a human gives the
+   go-ahead.
+3. After merge, open a separate PR that applies the listed items, plus
+   any other in-scope issue noticed while editing (correctness,
+   convention, mechanical style, or a single-paragraph-scoped
+   improvement) — never a multi-paragraph or section-level rewrite,
+   even if it would clearly improve the post.
+
+## Posting review comments
 
 Standing rule 1 (terse prose) [[10]](#references) applies to PR review
 comments and descriptions, not just post prose. State the finding or
@@ -171,6 +223,10 @@ explain why you're mentioning something — that's meta-commentary the
 reader doesn't need to act on the finding. If new context changes a
 finding, edit the existing comment in place instead of posting a
 follow-up correction.
+
+Every comment, review, or PR description needs a human's explicit
+approval of its exact text before it reaches GitHub. This is never an
+automated step, however routine the finding.
 
 ## References
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,216 @@
+# AGENTS.md
+
+Instructions for any coding agent writing or reviewing content in this
+repository. Human contributors should read [write-up.qmd](write-up.qmd)
+and [contributing.qmd](contributing.qmd) instead — this file exists so
+an agent doesn't have to be re-briefed on repo conventions and writing
+standards every session.
+
+## About this repository
+
+NBIS Tech Group: RSE Tools — short (~30-40 minute) walkthroughs on
+Research Software Engineering tools, each first given as a live talk
+with a demo, then written up as a blog post for
+[the site](https://nbisweden.github.io/Training-Tech-shorts/). Audience
+is NBIS staff and affiliates, mostly bioinformaticians, with a wide
+range of prior experience with any given topic — some attendees are
+complete beginners to it, others already use it daily.
+
+## Repository conventions
+
+- **Posts** live at `posts/YYYY-MM-DD-title-of-walkthrough/index.qmd`
+  (Quarto Markdown), with images in a sibling `images/` directory and
+  other assets in their own named directory. See
+  [write-up.qmd](write-up.qmd) for the full authoring workflow.
+- **Frontmatter** needs `title`, `date`, `date-modified: last-modified`,
+  `author`, and `categories`. Add `draft: true` for a post that hasn't
+  been given/scheduled yet — Quarto renders it in `quarto preview` but
+  excludes it from the published site's listings and navigation
+  (https://quarto.org/docs/websites/website-drafts.html). Remove the
+  `draft` field only once the session has actually been given and the
+  content and date are settled — don't remove it just because the
+  writing is finished.
+- **Branches** for a new post use `walkthrough/descriptive-name`, per
+  [write-up.qmd](write-up.qmd).
+- **Preview locally** with `quarto preview` (or `pixi run preview`).
+
+## Writing and reviewing walkthrough posts
+
+These are standing rules for this repo's posts, in addition to whatever
+the human author asks for on a given draft. They're grounded in
+learning-science and technical-writing research — see
+[References](#references) — not house-style opinion, so don't relax
+them without a reason that would also count as a reason in that
+literature.
+
+### Standing rules
+
+1. **Terse prose.** Follow the
+   [Google Developer Documentation Style Guide](https://developers.google.com/style)
+   [[10]](#references): short declarative sentences, active voice, no
+   hedges or meta-commentary ("it's worth noting," "note that," "worth
+   X-ing"). State the fact or rule directly instead of narrating that
+   you're about to explain it.
+2. **British English spelling** in prose (behaviour, summarise,
+   organise). Never touch code identifiers, CLI flags, package names, or
+   established field terminology, even where it's American-spelled — a
+   tool's actual name or a field's standard term isn't a prose choice to
+   "correct."
+3. **Each post stands alone.** No forward references within a post
+   ("as shown below," "we'll cover this later") — state the fact where
+   it's needed, or reorder so the explanation comes first. Don't link
+   from one post to another `posts/*/index.qmd` that still has
+   `draft: true`, framed as a prerequisite or "see also" — that post's
+   content and timing aren't settled yet. A post with no `draft` field
+   (already given) is safe to link to normally. External links (official
+   docs, tool sites, GitHub issues) are unaffected.
+4. **Scope to the session, not to the topic.** A post supports a
+   ~30-40 minute talk with a live demo — it is not a reference manual
+   for the tool. Implementation minutiae (every config key, every edge
+   case, every internal mechanism name) belong in the live demo, not in
+   written prose. See the checklist below for how to catch this.
+
+### The review checklist
+
+Run structural checks before line-editing — they catch whole-section
+problems sentence-level fixes can't reach. Numbers in brackets are full
+citations in [References](#references).
+
+1. **Mode check.** Per the Diátaxis framework [[5]](#references),
+   documentation has four distinct modes: tutorial, how-to, reference,
+   explanation. A walkthrough post is tutorial+explanation (attendees
+   learn by following a demo, and need the "why"). Any paragraph that
+   reads as "here's the complete set of X" has drifted into reference
+   mode — rewrite as one representative example plus a link, don't just
+   shorten the enumeration in place.
+2. **Task check.** Per Carroll's minimalism
+   [[4]](#references), does this paragraph support something the
+   attendee is about to do or understand right now? A true, accurate
+   fact that supports no immediate step is still a cut. Prefer noting
+   how to recognise and recover from a problem over exhaustively
+   enumerating every way it could occur in advance.
+3. **Narrative-arc check.** Does the post's section order read as a
+   line — tension then resolution, concept then consequence — rather
+   than a flat topic list? (Practitioner-level guidance, e.g. Atkinson
+   [[8]](#references); use as a tiebreaker, not a hard rule.)
+4. **Artifact-vs-narration check.** For anything demoable, keep the one
+   canonical working artifact written out in full (the exact command,
+   the complete config) — a live demo is bad at leaving attendees
+   something to copy afterward, so that part earns its place in prose.
+   But cut narration of internal branches, alternate paths, or edge
+   cases; show those live instead of enumerating them.
+5. **Coherence check.** Per Mayer's coherence principle
+   [[3]](#references) — the largest-effect-size of his multimedia
+   learning principles — if deleting a sentence doesn't weaken the point
+   it sits in, delete it, regardless of whether it's true or
+   interesting.
+6. **Justification-clause check.** A specific, common case of #1/#5:
+   watch for "X, because Y" or "this matters because Y" where Y is a
+   fact not otherwise needed near this sentence. Cut Y, or move it to
+   where it's actually needed instead.
+7. **Signaling check.** Per Mayer's signaling principle
+   [[3]](#references), a list mixing universal concepts and
+   product-specific names needs one sentence up front saying which is
+   which.
+8. **Split-attention check.** Per Chandler & Sweller
+   [[2]](#references), a code block's explanation must sit adjacent to
+   it. Flag any later paragraph that requires re-holding an earlier code
+   block in memory ("as configured above").
+9. **Redundancy check.** Per Mayer's redundancy principle
+   [[3]](#references), where a demo will show something verbatim
+   on-screen, prose shouldn't re-derive or re-explain it field-by-field —
+   name only what matters.
+10. **Curse-of-knowledge check.** Run an independent, no-context
+    beginner read on the draft, not just the author's own re-read —
+    fluency with a topic hides the gaps in your own explanation of it
+    [[7]](#references).
+11. **Expertise-reversal check.** Per Kalyuga
+    [[6]](#references), heavy scaffolding that helps a novice can
+    actively cost an expert reading the same sentence. For a
+    mixed-audience post, keep beginner aids skippable in under a
+    second — a short parenthetical an expert's eye slides past — rather
+    than a separate explanatory sentence.
+12. **Density re-check after any accuracy fix.** Correcting a factual
+    error tends to add supporting detail, not remove it. Immediately
+    after fixing a wrong claim, re-scan that specific paragraph against
+    checks 1, 4, and 5 — don't assume correctness was the only thing
+    that changed.
+13. **Retrieval-framing check.** Per the testing effect
+    [[9]](#references), actively recalling information beats re-reading
+    it for retention. Where practical, phrase the 1-2 most important
+    "Key takeaways" so the presenter can pose them as a live question to
+    the room, not only state them as a fact for the reader.
+14. **Accuracy pass.** Verify commands, config, model/tool names, and
+    behavior against current official docs — this space goes stale
+    fast. Don't rely on training-data recall for anything version- or
+    date-sensitive.
+15. **Style pass.** Apply the standing rules above (terse prose, British
+    spelling). Run this last — it's the cheapest to fix and shouldn't
+    gate the structural checks above it.
+
+### Recommended review process
+
+For a non-trivial draft, run two independent reviews rather than one
+self-review, since check 10 above specifically requires it:
+
+- **A beginner-lens pass** — read with no assumed prior knowledge of the
+  topic, checking flow, jargon scaffolding, and pacing (checks 1, 3, 7,
+  10, 11).
+- **An expert-lens pass** — verify factual/technical claims against
+  current official sources (check 14).
+
+Then run a **scope pass** over the result specifically for checks 1, 4,
+5, and 12.
+
+## References
+
+1. Cognitive load theory (Sweller) — working memory capacity is limited,
+   and load splits into intrinsic, extraneous, and germane categories.
+   https://en.wikipedia.org/wiki/Cognitive_load
+2. Split-attention effect (Chandler & Sweller, 1992) — separating a
+   diagram or code block from the text explaining it forces the reader
+   to hold one in memory while processing the other, at a measurable
+   cost to learning.
+   https://en.wikipedia.org/wiki/Split-attention_effect
+3. Multimedia learning principles (Mayer) — coherence, signaling,
+   redundancy, and spatial/temporal contiguity reduce extraneous
+   cognitive load; effect sizes for these are among the largest and most
+   replicated in the instructional-design literature (coherence and
+   redundancy ~0.86, spatial/temporal contiguity >1.0).
+   https://www.cambridge.org/core/books/abs/cambridge-handbook-of-multimedia-learning/principles-for-reducing-extraneous-processing-in-multimedia-learning-coherence-signaling-redundancy-spatial-contiguity-and-temporal-contiguity-principles/CD5B7AE1279A9AB81F8EEBB53DBEC86E
+4. Minimalism in technical communication (Carroll, *The Nürnberg
+   Funnel*) — task-oriented instruction that supports real tasks
+   immediately, and treats errors as something to recognise and recover
+   from rather than prevent through exhaustive up-front explanation.
+   https://en.wikipedia.org/wiki/Minimalism_(technical_communication)
+5. The Diátaxis framework — documentation has four distinct modes
+   (tutorial, how-to guide, reference, explanation), each meant to stay
+   separate.
+   https://diataxis.fr/
+6. Expertise reversal effect (Kalyuga) — instructional support that
+   helps a novice can have negative consequences for a more experienced
+   learner reading the same material.
+   https://en.wikipedia.org/wiki/Expertise_reversal_effect
+7. The curse of knowledge, applied to documentation — writers
+   overestimate what readers already know because their own fluency
+   makes the material feel self-evident; independent review by someone
+   matching the audience is the standard mitigation.
+   https://docsbydesign.com/2022/01/30/how-to-not-suffer-the-curse-of-knowledge/
+8. *Beyond Bullet Points* (Atkinson) — presentations built around a
+   narrative arc (setup, complication, resolution) read more clearly
+   than a flat list of topics. Practitioner source, not a peer-reviewed
+   study — used here as a tiebreaker, not a hard rule.
+   https://www.microsoftpressstore.com/articles/article.aspx?p=2916274
+9. The testing effect (Roediger & Karpicke, 2006) — actively retrieving
+   information produces better long-term retention than passive
+   re-study or re-reading.
+   https://journals.sagepub.com/doi/10.1111/j.1467-9280.2006.01693.x
+10. Google Developer Documentation Style Guide — editorial guidelines
+    for technical documentation, including tone, voice, and conciseness.
+    https://developers.google.com/style
+
+One heuristic in the checklist above (item 4, preserving one canonical
+artifact over narrating live-demo internals) reflects general live-demo
+practice rather than a specific verified study — flagged here rather
+than attached to an uncertain citation, per the standard of only citing
+sources that were actually checked to support their claim.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,6 +162,16 @@ self-review, since check 10 above specifically requires it:
 Then run a **scope pass** over the result specifically for checks 1, 4,
 5, and 12.
 
+### Posting review comments
+
+Standing rule 1 (terse prose) [[10]](#references) applies to PR review
+comments and descriptions, not just post prose. State the finding or
+recommendation directly. Don't narrate your own reasoning process or
+explain why you're mentioning something — that's meta-commentary the
+reader doesn't need to act on the finding. If new context changes a
+finding, edit the existing comment in place instead of posting a
+follow-up correction.
+
 ## References
 
 1. Cognitive load theory (Sweller) — working memory capacity is limited,

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ These people are responsible for organizing the sessions and maintaining this re
 
 ## How It Works
 
-Walkthroughs are short (~30 minutes) demonstrations, taught by volunteers from within the Tech group.
+Walkthroughs are short (~30-40 minutes) demonstrations, taught by volunteers from within the Tech group.
 The sessions are then written up and shared here for future reference as blog posts.
 
 ### Target Audience

--- a/contributing.qmd
+++ b/contributing.qmd
@@ -2,7 +2,7 @@
 
 ## How It Works
 
-Walkthroughs are short (~30 minutes) demonstrations, taught by volunteers from within the Tech group.
+Walkthroughs are short (~30-40 minutes) demonstrations, taught by volunteers from within the Tech group.
 The sessions are then written up and shared here for future reference as blog posts.
 
 ### Target Audience

--- a/write-up.qmd
+++ b/write-up.qmd
@@ -1,6 +1,6 @@
 # Writing a blog post
 
-This guide explains how to write up a blog post following a walkthrough. For information on suggesting topics or volunteering to teach, see [CONTRIBUTING](contributing.qmd).
+This guide explains how to write up a blog post following a walkthrough. For information on suggesting topics or volunteering to teach, see [CONTRIBUTING](contributing.qmd). For the writing-style rules and review checklist applied to drafts (and used by AI coding agents helping with a write-up), see [AGENTS.md](https://github.com/NBISweden/Training-Tech-shorts/blob/main/AGENTS.md) in the repository root.
 
 ## File Structure
 
@@ -32,12 +32,19 @@ Blog posts are written in [Quarto Markdown](https://quarto.org/docs/authoring/ma
    title: "Introduction to Docker"
    date: 2024-01-15
    date-modified: last-modified
-   author: 
+   draft: true
+   author:
      - Author Name
      - Coauthor Name
    categories: [ "Docker", "Containers", "Package management" ]
    ---
    ```
+
+   `draft: true` keeps a post out of the published site's listings while
+   it's still being written or hasn't been scheduled yet — Quarto still
+   renders it in `quarto preview`. Remove the `draft` field once the
+   session has actually been given and the content and date are settled,
+   not just once the writing is finished.
 
 4. **Write your content** using Markdown. Include:
 
@@ -90,10 +97,12 @@ Blog posts are written in [Quarto Markdown](https://quarto.org/docs/authoring/ma
 
 ## Writing Tips
 
-- Keep it concise and focused (~30 minute read)
+- Keep it concise and focused — a post supports a ~30-40 minute talk with a live demo, it's not a reference manual for the tool
+- A post should stand alone: don't assume the reader has seen another still-unpublished walkthrough, and don't forward-reference content later in the same post
 - Use code blocks with syntax highlighting and [code annotation](https://quarto.org/docs/authoring/code-annotation.html)
 - Include practical examples
 - Add links to relevant documentation
 - Consider adding a "Prerequisites" section if needed
 - **See existing posts** in the `posts/` directory for examples and inspiration
 - Check the [Quarto documentation](https://quarto.org/docs/authoring/markdown-basics.html) for advanced formatting options
+- See [AGENTS.md](https://github.com/NBISweden/Training-Tech-shorts/blob/main/AGENTS.md) for the fuller style and review checklist (prose style, scope, and independence rules with their reasoning)


### PR DESCRIPTION
## Description

Adds `AGENTS.md` at the repo root: a single instruction set any coding agent can use to write or review a walkthrough post, covering repo conventions (post structure, frontmatter, `draft: true`, branch naming) plus a 15-item review checklist grounded in cognitive load theory, the Diátaxis framework, Mayer's multimedia learning principles, Carroll's minimalism, and related literature. Every citation was checked against the source to confirm it actually supports the claim next to it, not just asserted.

Also:
- Adds the `draft: true` convention and the post-independence rule to `write-up.qmd`.
- Syncs the "~30 minutes" session-length wording in `contributing.qmd`/`README.md` to "~30-40 minutes," matching what `AGENTS.md` now states.
- Points `write-up.qmd` at `AGENTS.md` for the fuller rationale.

## Checklist

- [x] Preview locally with `quarto preview` - no errors or warnings
- [ ] Added any non-standard assets to `.github/_quarto.yml` ignore list (if needed) — n/a, no new assets